### PR TITLE
gimme-the-jamin.sh: export PATH so feature scripts find Entware tools

### DIFF
--- a/gimme-the-jamin.sh
+++ b/gimme-the-jamin.sh
@@ -4,6 +4,13 @@ set -xe
 
 SCRIPT_DIR=$(readlink -f $(dirname ${0}))
 
+# Ensure Entware (/opt/bin) and any UDISK-installed binaries are on PATH
+# so feature install scripts can find git/curl/jq/unzip etc. Several
+# feature scripts (e.g. cartographer/install.sh) call `git clone`
+# directly without an absolute path; on stock K2 Plus the default PATH
+# does not include /opt/bin, so the call silently fails.
+export PATH="/opt/bin:/opt/sbin:/mnt/UDISK/bin:$PATH"
+
 install_feature() {
     FEATURE=${1}
     if [ ! -f /tmp/${FEATURE} ]; then


### PR DESCRIPTION
Stock K2 Plus PATH does not include /opt/bin (where Entware installs git, curl, jq, unzip after `features/entware/install.sh`). Several of the feature install scripts that gimme-the-jamin invokes call those tools directly — most visibly `features/cartographer/install.sh` does `git clone https://github.com/.../cartographer3d-plugin.git` with no absolute path. The clone silently fails when /opt/bin is missing from PATH, leaving the cartographer feature half-installed.

Export the right PATH at the top of the script so all child feature scripts inherit it. /mnt/UDISK/bin is also included for compatibility with better-init's wrapper scripts (sudo, supervisorctl, systemctl).