### PR TITLE
better-root: idempotent link_up + don't kill SSH on non-interactive runs

### DIFF
--- a/features/better-root/install.sh
+++ b/features/better-root/install.sh
@@ -18,12 +18,15 @@ move_homedir() {
 
 link_up() {
     cd /mnt/UDISK/root
-    # link up the various printer bits in their normal location
-    ln -s /usr/share/klipper .
-    ln -s /usr/share/klippy-env/ .
-    ln -s /mnt/UDISK/printer_data/ .
-    ln -s /usr/share/moonraker .
-    ln -s /usr/share/moonraker-env .
+    # link up the various printer bits in their normal location.
+    # `ln -sfn` is idempotent: re-running this script (or running it after
+    # moonraker has already been installed by a feature pack) won't fail
+    # with "File exists" the way bare `ln -s` does.
+    ln -sfn /usr/share/klipper       klipper
+    ln -sfn /usr/share/klippy-env    klippy-env
+    ln -sfn /mnt/UDISK/printer_data  printer_data
+    [ -d /usr/share/moonraker ]     && ln -sfn /usr/share/moonraker     moonraker
+    [ -d /usr/share/moonraker-env ] && ln -sfn /usr/share/moonraker-env moonraker-env
 }
 
 aliases() {
@@ -41,7 +44,18 @@ link_up
 #aliases
 
 echo "I: you need to log back in for changes to take effect!"
-echo "I: logging you out now!"
-echo "I: please reconnect to continue"
-# terminate the SSH session
-pgrep dropbear | grep -v "^$(pgrep -o dropbear)$" | xargs kill -9
+# Only force-disconnect the SSH session in interactive runs. When this
+# script is invoked from an automated installer or another script,
+# killing dropbear processes prevents the parent script from continuing
+# (the dropbear that owns the SSH session may itself host the parent's
+# stdout). Detect interactivity via a TTY on stdin.
+if [ -t 0 ]; then
+    echo "I: logging you out now!"
+    echo "I: please reconnect to continue"
+    # terminate the SSH session
+    pgrep dropbear | grep -v "^$(pgrep -o dropbear)$" | xargs kill -9
+else
+    echo "I: non-interactive run detected; not killing SSH. The caller"
+    echo "I: must reconnect (or re-source /etc/passwd in the parent shell)"
+    echo "I: for the new \$HOME to take effect."
+fi


### PR DESCRIPTION
Two related changes that make better-root safe to invoke from automated installers (and safe to re-run by hand):

1. link_up() now uses `ln -sfn` (force, no-deref) and probes for the moonraker source directories before symlinking. The bare `ln -s` versions fail with `File exists` if any of the targets already resolve — which they do whenever a feature pack has installed moonraker before better-root runs, or whenever this script is re-invoked. With `set -e` upstream, that single failure aborts the whole install. The new form is idempotent and never errors on pre-existing symlinks.

2. The SSH-kill at the end now only fires when stdin is a TTY (`[ -t 0 ]`). Interactive users still get the existing behavior — forced logout so the new $HOME takes effect on next login. Non-interactive callers (an installer script, ssh-with-stdin-piped-input, etc.) instead get a printed warning and the script returns normally, letting the parent continue. Killing dropbear in non-interactive contexts can take down the very process whose stdout the caller is reading, terminating the parent install.

Both changes preserve the original interactive UX exactly; the only behavior change for end users is that re-runs no longer fail with File exists, and automated installs no longer get cut off mid-run.