### PR TITLE
better-init: mkdir -p /etc/profile.d before writing better-init.sh

### DIFF
--- a/features/better-init/install.sh
+++ b/features/better-init/install.sh
@@ -20,4 +20,5 @@ ln -sf ${SCRIPT_DIR}/bin/supervisorctl /mnt/UDISK/bin/
 ln -sf ${SCRIPT_DIR}/bin/systemctl /mnt/UDISK/bin/
 
 # update the path
+mkdir -p /etc/profile.d
 echo 'export PATH=/mnt/UDISK/bin:$PATH' > /etc/profile.d/better-init.sh


### PR DESCRIPTION
Stock K2 Plus firmware (verified on 1.1.5.2 / CR0CN240110C10) does not ship with `/etc/profile.d/` even though `/etc/profile` already sources `/etc/profile.d/*.sh`. When better-init's install.sh is the first feature to write into that directory (which it is, when invoked via `gimme-the-jamin.sh`), the redirect fails:

    can't create /etc/profile.d/better-init.sh: nonexistent directory

`set -e` then halts the install, leaving the printer in a partial state.

Add `mkdir -p /etc/profile.d` immediately before the redirect so the script is robust to the directory not pre-existing. Idempotent and zero-cost on firmware versions that already ship the directory.