### PR TITLE
cartographer: strip orphan SAVE_CONFIG [prtouch_v3] header on install

### DIFF
--- a/features/cartographer/install.sh
+++ b/features/cartographer/install.sh
@@ -46,6 +46,17 @@ fi
 
 # update printer config
 python ${SCRIPT_DIR}/alter_config.py
+# alter_config.py removes the active [prtouch_v3] section but is unaware of
+# Klipper's SAVE_CONFIG block (lines prefixed with `#*# `). Any printer that
+# has run prtouch_v3 calibration before this install will have a stale
+# `#*# [prtouch_v3]` header at the bottom of printer.cfg, which Klipper
+# loads back into the live config and then errors out:
+#   "Option 'step_swap_pin' in section 'prtouch_v3' must be specified"
+# Strip just the orphan header line so Klipper no longer tries to load the
+# section.
+if [ -f ~/printer_data/config/printer.cfg ]; then
+    sed -i '/^#\*# \[prtouch_v3\]$/d' ~/printer_data/config/printer.cfg
+fi
 python ${SCRIPT_DIR}/../../scripts/ensure_included.py \
     ~/printer_data/config/custom/main.cfg prtouch_v3.cfg True
 python ${SCRIPT_DIR}/../../scripts/ensure_included.py \


### PR DESCRIPTION
`alter_config.py` correctly removes the active `[prtouch_v3]` section from `printer.cfg`, but it's unaware of Klipper's SAVE_CONFIG block (lines prefixed with `#*# `). Any K2 Plus that has previously run prtouch_v3 calibration — which is essentially every printer being upgraded to use Cartographer — has a `#*# [prtouch_v3]` header in the SAVE_CONFIG block at the bottom of printer.cfg.

Klipper merges SAVE_CONFIG entries back into the live config at load time, so after the cartographer install removes the active section, the orphan SAVE_CONFIG header re-introduces a `[prtouch_v3]` section that's missing its required options. Klipper then refuses to start:

    Option 'step_swap_pin' in section 'prtouch_v3' must be specified

Strip just the orphan header line with sed after running alter_config.py. The associated value lines under it become unattached to any section and Klipper's SAVE_CONFIG parser ignores them — exactly what we want, since the values were calibration data for a probe we're no longer using.

Defensive `[ -f ... ]` guard in case the file does not exist yet (fresh install with no prior calibration).

Verified on K2 Plus 1.1.5.2; same code path applies to 1.1.3.13 / 1.1.4.x users upgrading from prtouch_v3.